### PR TITLE
chore: update gasolina version to 1.1.34 and add Sui provider (#57)

### DIFF
--- a/cdk/gasolina/config/index.ts
+++ b/cdk/gasolina/config/index.ts
@@ -13,10 +13,10 @@ export const CONFIG: {
     // EDIT: aws account number
     '824247070589': {
         gasolinaRepo: 'us-east1-docker.pkg.dev/lz-docker/gasolina/gasolina',
-        appVersion: '1.1.33', // EDIT: version and tag of the gasolina image
+        appVersion: '1.1.34', // EDIT: version and tag of the gasolina image
         projectName: 'layerzero-gasolina', // EDIT: project_name e.g. foobar-gasolina
         environment: 'mainnet', // EDIT: environment e.g. mainnet/testnet
-        availableChainNames: 'abstract,animechain,ape,apexfusionnexus,aptos,arbitrum,astar,aurora,avalanche,base,bb1,bera,bitlayer,blast,bob,botanix,bsc,canto,celo,codex,concrete,conflux,coredao,cronosevm,cronoszkevm,cyber,degen,dexalot,dfk,dos,edu,ethereum,etherlink,fantom,flare,flow,fraxtal,fuse,glue,gnosis,goat,gravity,gunz,harmony,hedera,hemi,hyperliquid,initia,ink,iota,islander,joc,katana,kava,klaytn,lens,lightlink,lisk,manta,mantle,merlin,meter,metis,mode,moonbeam,moonriver,morph,movement,mp1,nibiru,opbnb,optimism,orderly,peaq,plasma,plume,plumephoenix,polygon,rarible,real,rootstock,scroll,sei,shimmer,silicon,solana,somnia,soneium,sonic,sophon,story,subtensorevm,superposition,swell,tac,taiko,telos,tomo,ton,tron,unichain,worldchain,xai,xchain,xdc,xlayer,xpla,zircuit,zkconsensys,zkpolygon,zksync,zora',
+        availableChainNames: 'abstract,animechain,ape,apexfusionnexus,aptos,arbitrum,astar,aurora,avalanche,base,bb1,bera,bitlayer,blast,bob,botanix,bsc,canto,celo,codex,concrete,conflux,coredao,cronosevm,cronoszkevm,cyber,degen,dexalot,dfk,dos,edu,ethereum,etherlink,fantom,flare,flow,fraxtal,fuse,glue,gnosis,goat,gravity,gunz,harmony,hedera,hemi,hyperliquid,initia,ink,iota,islander,joc,katana,kava,klaytn,lens,lightlink,lisk,manta,mantle,merlin,meter,metis,mode,moonbeam,moonriver,morph,movement,mp1,nibiru,opbnb,optimism,orderly,peaq,plasma,plume,plumephoenix,polygon,rarible,real,rootstock,scroll,sei,shimmer,silicon,solana,somnia,soneium,sonic,sophon,story,subtensorevm,sui,superposition,swell,tac,taiko,telos,tomo,ton,tron,unichain,worldchain,xai,xchain,xdc,xlayer,xpla,zircuit,zkconsensys,zkpolygon,zksync,zora',
         signerType: 'KMS', // EDIT: MNEMONIC or KMS
         kmsNumOfSigners: 1, // EDIT: only required if signerType is KMS
         // extraContextRequestUrl: undefined // EDIT: optional

--- a/cdk/gasolina/config/providers/mainnet/providers.json
+++ b/cdk/gasolina/config/providers/mainnet/providers.json
@@ -560,6 +560,12 @@
             "https://erpc.nethermind.io/layerzero-gasolina-api/evm/964?token=${ERPC_AUTH_TOKEN}"
         ]
     },
+    "sui": {
+        "quorum": 1,
+        "uris": [
+            "https://fullnode.mainnet.sui.io/"
+        ]
+    },
     "superposition": {
         "quorum": 1,
         "uris": [


### PR DESCRIPTION
- Bump gasolina image version to 1.1.34 in configuration.
- Add new Sui provider configuration with quorum and URIs in providers.json.
